### PR TITLE
Defining open graphs

### DIFF
--- a/OpenGraph.elm
+++ b/OpenGraph.elm
@@ -1,0 +1,10 @@
+module OpenGraph where
+
+import Graph exposing (..)
+
+type OpenGraphType = EdgePoint | Vertex
+
+type alias OpenGraph e v = 
+    { graph : Graph e v
+    , typing : v -> Typegraph
+    }  


### PR DESCRIPTION
The category of open graphs is a subcategory of the slice category **Graph/2G**, where **2G** is the typing graph: 
![typing](https://cloud.githubusercontent.com/assets/5337877/9885542/f78b9852-5be5-11e5-9a5a-7efa91c85cb9.png)
It is a subcategory because it imposes the additional restriction that morphisms must be full on vertices. We need to define this structure in Elm.
